### PR TITLE
specify type on aceEditorContainer

### DIFF
--- a/md-editor/md-editor.component.ts
+++ b/md-editor/md-editor.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, forwardRef, Renderer, Attribute, Input } from '@angular/core';
+import { Component, ViewChild, forwardRef, Renderer, Attribute, Input, ElementRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor, NG_VALIDATORS, Validator, AbstractControl, ValidationErrors } from '@angular/forms';
 import { DomSanitizer } from '@angular/platform-browser';
 
@@ -26,7 +26,7 @@ declare let hljs: any;
 
 export class MarkdownEditorComponent implements ControlValueAccessor, Validator {
 
-  @ViewChild('aceEditor') aceEditorContainer;
+  @ViewChild('aceEditor') aceEditorContainer:ElementRef;
 
   @Input()
   hideToolbar: boolean = false;


### PR DESCRIPTION
I get this error when I ran my app, then I guess it's fixed: 

 ERROR in [at-loader] ./node_modules/ngx-markdown-editor/md-editor/md-editor.component.ts:29:3 
    TS7008: Member 'aceEditorContainer' implicitly has an 'any' type.